### PR TITLE
Rename cargo.toml to correct capitalization; update polars dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 serde = ">=1.0.210"
 statrs = ">=0.17.1"
-polars = "0.43.1"
+polars = "0.49.1"


### PR DESCRIPTION
- Rename `cargo.toml` to the correct capitalization: `Cargo.toml`
- update `polars` dependency to `0.49.1`